### PR TITLE
`notFound` method to have access to `middleware.`

### DIFF
--- a/docs/examples/middleware.js
+++ b/docs/examples/middleware.js
@@ -1,0 +1,17 @@
+/* eslint no-console: 0 */
+
+const rayo = require('../../packages/rayo');
+const send = require('../../packages/send');
+
+const options = {
+  port: 5050,
+  onError: (error, req, res) => res.send({ error }, 409),
+  notFound: (req, res) => res.send({ error: `${req.url} not found` }, 404)
+};
+
+rayo(options)
+  .through(send())
+  .get('/', (req, res, step) => step('Thrown by the step function...'))
+  .start((address) => {
+    console.log(`Up on port ${address.port}`);
+  });

--- a/packages/rayo/bridge.js
+++ b/packages/rayo/bridge.js
@@ -81,7 +81,7 @@ module.exports = class Bridge {
       ? null
       : {
           params: exec(path, url),
-          stack: this.t.concat(this.s[verb][url[0].old])
+          stack: this.s[verb][url[0].old]
         };
   }
 };


### PR DESCRIPTION
As suggested here: https://github.com/GetRayo/rayo.js/issues/135

**TODO:** Needs unit tests.