### PR TITLE
Fixed .start(callback) example code in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -396,7 +396,7 @@ server.start();
 ```js
 const rayo = require('rayo');
 
-rayo({ port: 5050 });
+rayo({ port: 5050 })
   .get((req, res) => res.end('Thunderstruck'))
   .start((address) => {
     console.log(`Rayo is up on port ${address.port}`);


### PR DESCRIPTION
I noticed a simple JS syntax error in one of the examples of the README, so here's the fix!